### PR TITLE
Make GitHub links on index page point to posts

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,7 +31,7 @@ image:
       <em>Updated: {{ post.last_modified | time_zone: 'America/Los_Angeles' | date: "%-m/%-d/%Y %l:%M %p %Z"}}</em>
     </small><br>
     <small>
-     <a href="https://github.com/mkiser/WTFJHT/edit/master/{{ page.path }}" target="_blank">Help improve this article</a> |  <a href="https://github.com/mkiser/WTFJHT/commits/master/{{ page.path }}" target="_blank">See revision history</a>
+     <a href="https://github.com/mkiser/WTFJHT/edit/master/{{ post.path }}" target="_blank">Help improve this article</a> |  <a href="https://github.com/mkiser/WTFJHT/commits/master/{{ post.path }}" target="_blank">See revision history</a>
     </small>
   </time>
 


### PR DESCRIPTION
...not to the index page.

The real solution is to share a "post" include between the post page and the index page, so that there aren't slight inconsistencies between `index.html` and `_layouts/post.html`, but this works for now!