### PR TITLE
Don't fetch github-pages gem version from the web

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,10 +1,6 @@
 source 'https://rubygems.org'
 
-require 'json'
-require 'open-uri'
-versions = JSON.parse(open('https://pages.github.com/versions.json').read)
-
-gem 'github-pages', versions['github-pages']
+gem 'github-pages'
 gem 'jekyll-sitemap'
 gem 'amp-jekyll'
 gem 'jekyll-paginate'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -26,7 +26,7 @@ GEM
       bundler
       rake
       thor (>= 0.14.0)
-    awesome_print (1.7.0)
+    awesome_print (1.8.0)
     coffee-script (2.4.1)
       coffee-script-source
       execjs
@@ -112,7 +112,7 @@ GEM
       coffee-script (~> 2.2)
     jekyll-default-layout (0.1.4)
       jekyll (~> 3.0)
-    jekyll-extlinks (0.0.3)
+    jekyll-extlinks (0.0.4)
       jekyll (~> 3.0)
       nokogiri (~> 1.6)
     jekyll-feed (0.9.2)
@@ -188,23 +188,23 @@ GEM
       rb-fsevent (>= 0.9.3)
       rb-inotify (>= 0.9.7)
     mercenary (0.3.6)
-    mini_portile2 (2.1.0)
+    mini_portile2 (2.2.0)
     minima (2.1.1)
       jekyll (~> 3.3)
     minitest (5.10.2)
     multipart-post (2.0.0)
     net-dns (0.8.0)
-    nokogiri (1.7.2)
-      mini_portile2 (~> 2.1.0)
+    nokogiri (1.8.0)
+      mini_portile2 (~> 2.2.0)
     octokit (4.7.0)
       sawyer (~> 0.8.0, >= 0.5.3)
     pathutil (0.14.0)
       forwardable-extended (~> 2.6)
     public_suffix (2.0.5)
     rake (12.0.0)
-    rb-fsevent (0.9.8)
-    rb-inotify (0.9.8)
-      ffi (>= 0.5.0)
+    rb-fsevent (0.10.2)
+    rb-inotify (0.9.10)
+      ffi (>= 0.5.0, < 2)
     rouge (1.11.1)
     safe_yaml (1.0.4)
     sass (3.4.24)
@@ -219,7 +219,7 @@ GEM
       ethon (>= 0.8.0)
     tzinfo (1.2.3)
       thread_safe (~> 0.1)
-    unicode-display_width (1.2.1)
+    unicode-display_width (1.3.0)
     verbal_expressions (0.1.5)
 
 PLATFORMS
@@ -228,7 +228,7 @@ PLATFORMS
 DEPENDENCIES
   algoliasearch-jekyll
   amp-jekyll
-  github-pages (= 140)
+  github-pages
   jekyll-extlinks
   jekyll-paginate
   jekyll-redirect-from
@@ -237,4 +237,4 @@ DEPENDENCIES
   jekyll_pages_api
 
 BUNDLED WITH
-   1.15.0
+   1.15.1


### PR DESCRIPTION
Without this change, I was unable to `bundle exec jekyll serve` locally (OS X 10.12.5, Ruby 2.4.1p111, rvm 1.29.2):

```
$ bundle exec jekyll serve
/Users/mark/.rvm/gems/ruby-2.4.1/gems/bundler-1.15.1/lib/bundler/runtime.rb:317:in `check_for_activated_spec!': You have already activated json 2.0.2, but your Gemfile requires json 1.8.6. Since json is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports json as a default gem. (Gem::LoadError)
```

The issue is that requiring `json` during evaluation of the `Gemfile` makes `bundler` unable to later dynamically change the version of `json` to match the one required (see "Execution" [here][1]).

Anyway, I don’t think it’s necessary to fetch the version number from the web since [`Gemfile.lock` determines what version is installed][2]. The official [GitHub Pages + Jekyll instructions][3] suggest specifying simply `gem 'github-pages', group :jekyll-plugins`.

[1]: http://yehudakatz.com/2011/05/30/gem-versioning-and-bundler-doing-it-right/

[2]: https://bundler.io/v1.3/man/bundle-install.1.html#DESCRIPTION

[3]: https://help.github.com/articles/setting-up-your-github-pages-site-locally-with-jekyll/#step-2-install-jekyll-using-bundler