### PR TITLE
Update 2017-07-31-day-193.markdown

### DIFF
--- a/_posts/2017-07-31-day-193.markdown
+++ b/_posts/2017-07-31-day-193.markdown
@@ -27,7 +27,7 @@ image: "/uploads/193.jpg"
 
 {% twitter https://twitter.com/SenSchumer/status/891359143923265537 %}
 
-* **Kellyanne Conway said Trump would make a decision "this week" on whether to make Obamacare payments**. Trump tweeted a warning on Saturday that if Congress didn't pass a bill to overhaul the Affordable Care Act soon, he would end the "bailouts" for insurance companies as well as members of Congress. ([CNN](http://www.cnn.com/2017/07/30/politics/kellyanne-conway-tom-price-obamacare/index.html))
+* **Kellyanne Conway said Trump would make a decision "this week" on whether to make Obamacare payments**. Trump tweeted a warning on Saturday that if Congress didn't pass a bill to overhaul the Affordable Care Act soon, he would end the "bailouts" for insurance companies as well as for members of Congress. ([CNN](http://www.cnn.com/2017/07/30/politics/kellyanne-conway-tom-price-obamacare/index.html))
 
 * **Susan Collins said Trump’s threats to cut off funding for key Obamacare payments won’t change her vote** on the GOP’s plan to repeal it. “It would not affect my vote on healthcare, but it’s an example of why we need to act: to make sure that those payments, which are not an insurance company bailout, but rather help people who are very low-income afford their out-of-pocket costs toward their deductibles and their co-pays,” Collins said. “It really would be detrimental to some of the most vulnerable citizens if those payments were cut off.” ([The Hill](http://thehill.com/homenews/senate/344549-collins-trumps-threat-to-end-obamacare-payments-wont-change-my-vote))
 
@@ -43,7 +43,7 @@ image: "/uploads/193.jpg"
 
 * **Pence reassured NATO’s Baltic member states that the US stands behind its mutual-defense commitment** and will "hold Russia accountable for its actions." ([Politico](http://www.politico.com/story/2017/07/31/mike-pence-russia-estonia-visit-241160))
 
-9/ **Russia slashed 60% of US embassy and consular staff in response to new American sanctions**. The US will need to cut 755 of it's roughly 1,200 diplomatic staff in Russia, meant to cause discomfort for Washington and its representatives in Moscow. ([New York Times](https://www.nytimes.com/2017/07/30/world/europe/russia-sanctions-us-diplomats-expelled.html) / [Reuters](https://www.reuters.com/article/us-usa-trump-russia-retaliation-putin-idUSKBN1AF0S5))
+9/ **Russia slashed 60% of US embassy and consular staff in response to new American sanctions**. The US will need to cut 755 of its roughly 1,200 diplomatic staff in Russia, meant to cause discomfort for Washington and its representatives in Moscow. ([New York Times](https://www.nytimes.com/2017/07/30/world/europe/russia-sanctions-us-diplomats-expelled.html) / [Reuters](https://www.reuters.com/article/us-usa-trump-russia-retaliation-putin-idUSKBN1AF0S5))
 
 10/ **Democrats have moved to revoke Jared Kushner’s security clearance**, introducing the Security Clearance Review Act, which gives the FBI Director the authority to revoke the security clearance of executive branch employees whose actions may pose a threat to national security. At least 20 Democrats have cosigned on the bill. ([Salon](http://www.salon.com/2017/07/28/democrats-move-to-revoke-jared-kushners-security-clearance/))
 


### PR DESCRIPTION
Added "for": "...as well as members of Congress" --> "...as well as for members of Congress."
Corrected "it's" to "its": "The US will need to cut 755 of it's roughly 1,200 diplomatic staff" --> "The US will need to cut 755 of its roughly 1,200 diplomatic staff"