### PR TITLE
Remove 'were'

### DIFF
--- a/_posts/2017-10-20-day-274.markdown
+++ b/_posts/2017-10-20-day-274.markdown
@@ -25,7 +25,7 @@ image: "/uploads/274.jpg"
 
 The troops were engaged in a firefight for 30 minutes and relied on French military for air support, which made low-pass flyovers in an attempt to disperse the attackers. It did not have permission to drop bombs.
 
-Private contractors were used helicopters to evacuate the injured and dead, but Army Sgt. La David Johnson was somehow left behind for almost two days before his remains were found.
+Private contractors used helicopters to evacuate the injured and dead, but Army Sgt. La David Johnson was somehow left behind for almost two days before his remains were found.
 
 Trump waited nearly two weeks before mentioning the Niger incident, even though his staff had drafted a statement of condolence for him on October 5th. Some have asked if this is [Trump's Benghazi](http://www.newsweek.com/niger-trumps-benghazi-four-us-soldiers-died-and-it-took-him-12-days-respond-688082). 
 


### PR DESCRIPTION
Alternatively could change to 'using'