### PR TITLE
Reword to remove ability to misread

### DIFF
--- a/_posts/2018-03-20-day-425.markdown
+++ b/_posts/2018-03-20-day-425.markdown
@@ -9,7 +9,7 @@ image: "/uploads/425.jpg"
 
 {% twitter https://twitter.com/realdonaldtrump/status/972829763067883523 %}
 
-2/ **Trump's asked a high-profile and seasoned litigator to join the team**. Theodore Olson served as solicitor general in the George W. Bush administration and has more experience on landmark cases than any of Trump's current lawyers. Olson, who previously declined an offer to join the team, is said to be reviewing a new offer. ([Washington Post](https://www.washingtonpost.com/politics/trump-legal-team-seeks-to-add-gravitas-with-offer-to-star-gop-attorney-theodore-b-olson/2018/03/20/571f1e46-2c41-11e8-8ad6-fbc50284fce8_story.html))
+2/ **Trump has asked a seasoned high-profile litigator to join the team**. Theodore Olson served as solicitor general in the George W. Bush administration and has more experience on landmark cases than any of Trump's current lawyers. Olson, who previously declined an offer to join the team, is said to be reviewing a new offer. ([Washington Post](https://www.washingtonpost.com/politics/trump-legal-team-seeks-to-add-gravitas-with-offer-to-star-gop-attorney-theodore-b-olson/2018/03/20/571f1e46-2c41-11e8-8ad6-fbc50284fce8_story.html))
 
 3/ **Paul Ryan says he received "assurances" that firing Robert Mueller is "not even under consideration."** The House Speaker did not elaborate on the assurances. Mitch McConnell, meanwhile, has yet to comment on Trump's Twitter attack on Mueller. In January, McConnell declined to take up proposed legislation to protect Mueller because he knew of no "official" White House effort to undermine him. ([CNN](https://www.cnn.com/2018/03/20/politics/paul-ryan-assurances-mueller-not-fired/index.html))
 


### PR DESCRIPTION
I thought it was two litigators, and the possessive also threw me. May want a comma as well.