### PR TITLE
Fix typo - global COVID numbers

### DIFF
--- a/_posts/2020-04-21-day-1188.markdown
+++ b/_posts/2020-04-21-day-1188.markdown
@@ -19,7 +19,7 @@ todayInOneSentence: The White House and congressional leaders reached agreement 
 
 * ### 🔥 Daily Damage Report.
 
-* **🌍 Global**: Total confirmed cases \~3,547,000; Total deaths: \~177,000; Total recoveries: \~680,000. ([Johns Hopkins University](https://coronavirus.jhu.edu/map.html))
+* **🌍 Global**: Total confirmed cases \~2,547,000; Total deaths: \~177,000; Total recoveries: \~680,000. ([Johns Hopkins University](https://coronavirus.jhu.edu/map.html))
 
 * **🇺🇸 U.S.**: Total confirmed cases \~817,000; Total deaths: \~44,300; Total recoveries: \~75,000
 


### PR DESCRIPTION
Current number of cases per your John Hopkins source (right now) is 2,563,384 so I assume it was ~2,547,000 at the time of publication.