### PR TITLE
Add "Today in one sentence" to RSS and Atom

### DIFF
--- a/atom.xml
+++ b/atom.xml
@@ -32,6 +32,10 @@ layout:
       {% include away_mode.html %}
     {% endif %}
 
+    {% if post.todayInOneSentence and post.todayInOneSentence != '' %}
+        &lt;p&gt;&lt;em&gt;&lt;strong&gt;Today in one sentence&lt;/strong&gt;: {{ post.todayInOneSentence }}&lt;/em&gt;&lt;/p&gt;
+    {% endif %}
+
     {{ post.content | xml_escape }}
     
     &lt;p&gt;&lt;strong&gt;Support today&#39;s essential newsletter and resist the daily shock and awe:&lt;/strong&gt; &lt;a href=&quot;{{ site.url }}{{ site.baseurl }}/membership&quot;&gt;Become a member&lt;/a&gt; &lt;/p&gt;

--- a/rss.xml
+++ b/rss.xml
@@ -19,13 +19,20 @@ layout:
         {% for post in site.posts limit:50 %}
         <item>
             <title>{{ post.title | xml_escape }}: {{ post.description | xml_escape }}</title>
+            {% assign desc = post.content %}
+            {% if post.todayInOneSentence and post.todayInOneSentence != '' %}
+                {% assign desc = post.todayInOneSentence %}
+            {% endif %}
             <description>
-                <![CDATA[{{ post.content | strip_html | truncate: 250 }} <p><strong>Subscribe:</strong> <a href="{{ site.url }}{{ site.baseurl }}/subscribe/" target="_blank">Get the Daily Update in your inbox for free</a></p>]]>
+                <![CDATA[{{ desc | strip_html | truncate: 250 }} <p><strong>Subscribe:</strong> <a href="{{ site.url }}{{ site.baseurl }}/subscribe/" target="_blank">Get the Daily Update in your inbox for free</a></p>]]>
             </description>
             <content:encoded>
                 <![CDATA[<img src="{{ site.url }}{{ site.baseurl }}{{ post.image }}"/> 
                 {% if site.is_away_mode == true %}
                     {% include away_mode.html %}
+                {% endif %}
+                {% if post.todayInOneSentence and post.todayInOneSentence != '' %}
+                    <p><em><strong>Today in one sentence</strong>: {{ post.todayInOneSentence }}</em></p>
                 {% endif %}
                 {{ post.content }} <p><strong>Subscribe:</strong> <a href="{{ site.url }}{{ site.baseurl }}/subscribe/" target="_blank">Get the Daily Update in your inbox for free</a></p><p><strong>Support today's essential newsletter and resist the daily shock and awe:</strong> <a href="{{ site.url }}{{ site.baseurl }}/membership">Become a member</a></p>]]>
             </content:encoded>


### PR DESCRIPTION
I love the "Today in one sentence" summary. This PR adds that summary to the top of RSS and Atom feed items. For RSS, it uses the sentence as the description (when available).

Example one post feeds:
- [rss.xml](https://github.com/user-attachments/files/19593985/rss.xml.txt)
- [atom.xml](https://github.com/user-attachments/files/19594003/atom.xml.txt)

- [ ] Question: Adding an `<hr>` below the sentence would emulate the website styles. Shall I add one?
